### PR TITLE
Refactor API config to use hostIp and port fields

### DIFF
--- a/api/server.go
+++ b/api/server.go
@@ -3,6 +3,7 @@ package api
 import (
 	"context"
 	"crypto/tls"
+	"fmt"
 	"humpback-agent/config"
 	"humpback-agent/controller"
 	"humpback-agent/model"
@@ -23,7 +24,7 @@ func NewAPIServer(controller controller.ControllerInterface, config *config.APIC
 	router := NewRouter(controller, config, token, tokenChan)
 	server := &APIServer{
 		svc: &http.Server{
-			Addr:         config.Bind,
+			Addr:         fmt.Sprintf(":%s", config.Port),
 			Handler:      router,
 			WriteTimeout: 90 * time.Second,
 			ReadTimeout:  30 * time.Second,

--- a/config.yaml
+++ b/config.yaml
@@ -1,13 +1,14 @@
 #API
 api:
-  bind: 0.0.0.0:8018
+  port: 8018
+  hostIp: 
   mode: debug
   middlewares: ["cors", "recovery", "logger"]
   versions: ["/v1"]
 
 # 服务器配置
 server:
-  host: 172.30.112.1:8801
+  host: 172.30.112.1:8101
   registerToken: OR9dfc2kTTD5it51
   health:
     interval: 30s

--- a/config/config.go
+++ b/config/config.go
@@ -26,7 +26,8 @@ var (
 )
 
 type APIConfig struct {
-	Bind        string   `json:"bind" yaml:"bind" env:"HUMPBACK_AGENT_API_BIND"`
+	Port        string   `json:"port" yaml:"port" env:"HUMPBACK_AGENT_API_PORT"`
+	HostIP      string   `json:"hostIp" yaml:"hostIp" env:"HUMPBACK_AGENT_API_HOST_IP"`
 	Mode        string   `json:"mode" yaml:"mode" env:"HUMPBACK_AGENT_API_MODE"`
 	Middlewares []string `json:"middlewares" yaml:"middlewares"`
 	Versions    []string `json:"versions" yaml:"versions"`

--- a/model/host.go
+++ b/model/host.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"runtime"
+	"strconv"
 
 	"humpback-agent/pkg/utils"
 )
@@ -48,8 +49,15 @@ type CertificateBundle struct {
 	KeyPEM   []byte         // PEM编码的私钥
 }
 
-func GetHostInfo(bind string) HostInfo {
+func GetHostInfo(hostIpStr, portStr string) HostInfo {
 	hostname, _ := os.Hostname()
+	port, _ := strconv.Atoi(portStr)
+	var hostIps []string
+	if hostIpStr != "" {
+		hostIps = []string{hostIpStr}
+	} else {
+		hostIps = utils.HostIPs()
+	}
 	osInfo := fmt.Sprintf("%s %s", runtime.GOOS, runtime.GOARCH)
 	kernelVersion := utils.HostKernelVersion()
 	totalCPU, usedCPU, cpuUsage := utils.HostCPU()
@@ -64,7 +72,7 @@ func GetHostInfo(bind string) HostInfo {
 		TotalMemory:   totalMEM,
 		UsedMemory:    usedMEM,
 		MemoryUsage:   memUsage,
-		HostIPs:       utils.HostIPs(),
-		HostPort:      utils.BindPort(bind),
+		HostIPs:       hostIps,
+		HostPort:      port,
 	}
 }

--- a/service/agent.go
+++ b/service/agent.go
@@ -347,7 +347,7 @@ func (agentService *AgentService) sendHealthRequest(ctx context.Context) error {
 	agentService.RUnlock()
 
 	payload := &model.HostHealthRequest{
-		HostInfo:     model.GetHostInfo(agentService.config.APIConfig.Bind),
+		HostInfo:     model.GetHostInfo(agentService.config.APIConfig.HostIP, agentService.config.APIConfig.Port),
 		DockerEngine: *dockerEngineInfo,
 		Containers:   containers,
 	}


### PR DESCRIPTION
Replaces the 'bind' field in API configuration with separate 'hostIp' and 'port' fields for improved clarity and flexibility. Updates related code to use the new configuration structure, including server initialization, logging, host info retrieval, and registration logic. Adjusts config.yaml and all affected function signatures and usages accordingly.